### PR TITLE
Added bindings to swap-window right / left by one position

### DIFF
--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -38,8 +38,8 @@ unbind "\$" # rename-session
 unbind ,    # rename-window
 unbind %    # split-window -h
 unbind '"'  # split-window
-unbind }    # swap-pane -D
-unbind {    # swap-pane -U
+#unbind }    # swap-pane -D
+#unbind {    # swap-pane -U
 #unbind [    # paste-buffer
 #unbind ]    
 unbind "'"  # select-window
@@ -85,7 +85,7 @@ bind -r C-] next-window
 #bind -r [ select-pane -t :.-
 #bind -r ] select-pane -t :.+
 bind -r Tab last-window   # cycle thru MRU tabs
-bind -r C-o swap-pane -D
+#bind -r C-o swap-pane -D
 
 # Zoom pane
 bind + resize-pane -Z
@@ -401,7 +401,12 @@ bind l select-pane -R
 
 # Show pane status on the border: Index: Title: Command
 set-option -g pane-border-status top
-set-option -g pane-border-format "#P: #T: #{pane_current_command} "
+set-option -g pane-border-format "#P: #h: #T: #{pane_current_command} "
+
+# https://superuser.com/questions/343572/how-do-i-reorder-tmux-windows
+# Pressing Ctrl+Shift+Left (will move the current window to the left. Similarly right. No need to use the modifier (C-b).
+bind-key -n C-S-Left swap-window -t -1
+bind-key -n C-S-Right swap-window -t +1
 
 # Source local configuration
 source-file ~/.tmux.conf.local


### PR DESCRIPTION
Reference: https://superuser.com/questions/343572/how-do-i-reorder-tmux-windows
>  Pressing Ctrl+Shift+Left (will move the current window to the left.
>  Similarly right. No need to use the modifier (C-b).

```
bind-key -n C-S-Left swap-window -t -1
bind-key -n C-S-Right swap-window -t +1
```

On branch added-swap-window-bindings

-  Changes to be committed:
   -	modified:   tmux/tmux.conf